### PR TITLE
feat: add predefined themes (Gboard, iOS) for easy styling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
   },
   "files.watcherExclude": {
     "**/.fvm": true
-  }
+  },
+  "cSpell.words": [
+    "Gboard"
+  ]
 }

--- a/packages/flutter_onscreen_keyboard/README.md
+++ b/packages/flutter_onscreen_keyboard/README.md
@@ -185,6 +185,23 @@ class _AppState extends State<App> {
 - **Layouts:** Use built-in or define your own layouts with multiple modes.
 - **Behaviors:** Override key presses and implement custom actions.
 
+### Predefined Themes
+
+Easily apply built-in keyboard styles like **Gboard** or **iOS** using predefined factory constructors:
+
+```dart
+OnscreenKeyboard.builder(
+  theme: OnscreenKeyboardThemeData.gBoard(),
+)
+```
+
+#### Available Themes:
+
+- `OnscreenKeyboardThemeData.gBoard()`
+- `OnscreenKeyboardThemeData.ios()`
+
+### Custom Theme
+
 An example of theme customization:
 
 ```dart

--- a/packages/flutter_onscreen_keyboard/example/pubspec.lock
+++ b/packages/flutter_onscreen_keyboard/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.6"
+    version: "0.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/packages/flutter_onscreen_keyboard/lib/src/layouts/mobile_layout.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/layouts/mobile_layout.dart
@@ -82,7 +82,7 @@ class MobileKeyboardLayout extends KeyboardLayout {
           onTap: (context) => context.controller.switchMode(),
           flex: 30,
         ),
-        const OnscreenKeyboardKey.text(primary: ','),
+        const OnscreenKeyboardKey.text(primary: '/'),
         const OnscreenKeyboardKey.text(
           primary: ' ',
           child: Icon(Icons.space_bar_rounded),

--- a/packages/flutter_onscreen_keyboard/lib/src/onscreen_keyboard.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/onscreen_keyboard.dart
@@ -607,6 +607,7 @@ class _ControlBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
+    final theme = context.theme;
 
     final Widget trailing;
     if (actions != null && actions!.isNotEmpty) {
@@ -647,7 +648,7 @@ class _ControlBar extends StatelessWidget {
     }
 
     return Material(
-      color: colors.surfaceContainer,
+      color: theme.controlBarColor ?? colors.surfaceContainer,
       child: IconButtonTheme(
         data: IconButtonThemeData(style: IconButton.styleFrom(iconSize: 16)),
         child: Row(

--- a/packages/flutter_onscreen_keyboard/lib/src/theme/onscreen_keyboard_theme_data.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/theme/onscreen_keyboard_theme_data.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/widgets.dart';
+// ignore_for_file: sort_constructors_first
+
+import 'package:flutter/material.dart';
 import 'package:flutter_onscreen_keyboard/src/models/keys.dart';
 
 /// Defines the visual styling for the onscreen keyboard widget.
@@ -18,6 +20,7 @@ class OnscreenKeyboardThemeData {
     this.padding,
     this.textKeyThemeData = const TextKeyThemeData(),
     this.actionKeyThemeData = const ActionKeyThemeData(),
+    this.controlBarColor,
   });
 
   /// The background color of the keyboard.
@@ -46,6 +49,70 @@ class OnscreenKeyboardThemeData {
 
   /// Theme data for styling action keys (e.g., Enter, Backspace, Shift).
   final ActionKeyThemeData actionKeyThemeData;
+
+  /// The background color of the control bar.
+  final Color? controlBarColor;
+
+  // predefined themes
+
+  /// Google Gboard theme.
+  factory OnscreenKeyboardThemeData.gBoard({Color? primary}) {
+    final color = primary ?? Colors.blue;
+    return OnscreenKeyboardThemeData(
+      color: Color.lerp(color, Colors.white, 0.8),
+      controlBarColor: Color.lerp(color, Colors.white, 0.8),
+      padding: const EdgeInsets.all(4),
+      borderRadius: BorderRadius.zero,
+      textKeyThemeData: TextKeyThemeData(
+        backgroundColor: Colors.white,
+        margin: const EdgeInsets.symmetric(horizontal: 2, vertical: 4),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      actionKeyThemeData: ActionKeyThemeData(
+        backgroundColor: Color.lerp(color, Colors.white, 0.5),
+        pressedBackgroundColor: color,
+        margin: const EdgeInsets.symmetric(
+          horizontal: 2,
+          vertical: 4,
+        ),
+        borderRadius: BorderRadius.circular(6),
+      ),
+    );
+  }
+
+  /// iOS theme data.
+  factory OnscreenKeyboardThemeData.ios() {
+    return OnscreenKeyboardThemeData(
+      color: const Color(0xFFD3D3D3),
+      controlBarColor: const Color(0xFFD3D3D3),
+      padding: const EdgeInsets.all(4),
+      borderRadius: BorderRadius.zero,
+      textKeyThemeData: TextKeyThemeData(
+        backgroundColor: Colors.white,
+        boxShadow: [
+          const BoxShadow(
+            offset: Offset(1, 1),
+            blurRadius: 0.2,
+            color: Colors.black45,
+          ),
+        ],
+        margin: const EdgeInsets.symmetric(horizontal: 3, vertical: 6),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      actionKeyThemeData: ActionKeyThemeData(
+        backgroundColor: const Color(0xFFADADAD),
+        boxShadow: [
+          const BoxShadow(
+            offset: Offset(1, 1),
+            blurRadius: 0.2,
+            color: Colors.black45,
+          ),
+        ],
+        margin: const EdgeInsets.symmetric(horizontal: 3, vertical: 6),
+        borderRadius: BorderRadius.circular(6),
+      ),
+    );
+  }
 }
 
 /// Base class for customizing the visual appearance and layout of keys.

--- a/packages/flutter_onscreen_keyboard/pubspec.yaml
+++ b/packages/flutter_onscreen_keyboard/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  very_good_analysis: ^8.0.0
+  very_good_analysis: ^9.0.0
 
 topics:
   - keyboard

--- a/packages/flutter_onscreen_keyboard/pubspec.yaml
+++ b/packages/flutter_onscreen_keyboard/pubspec.yaml
@@ -5,6 +5,8 @@ description: >
 
 version: 0.1.0
 
+resolution: workspace
+
 homepage: https://github.com/albinpk/flutter_onscreen_keyboard
 repository: https://github.com/albinpk/flutter_onscreen_keyboard
 issue_tracker: https://github.com/albinpk/flutter_onscreen_keyboard/issues

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -372,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: very_good_analysis
-      sha256: c529563be4cbba1137386f2720fb7ed69e942012a28b13398d8a5e3e6ef551a7
+      sha256: e479fbc0941009262343db308133e121bf8660c2c81d48dd8e952df7b7e1e382
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.0.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  boolean_selector:
+    dependency: transitive
+    description:
+      name: boolean_selector
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -57,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.2"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -73,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.1+1"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
   file:
     dependency: transitive
     description:
@@ -81,6 +113,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  flutter:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_test:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -129,22 +171,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.9"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.9"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
+  matcher:
+    dependency: transitive
+    description:
+      name: matcher
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.17"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.1"
   melos:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "4280dc46bd5b741887cce1e67e5c1a6aaf3c22310035cf5bd33dceeeda62ed22"
+      sha256: "51e7902a164d7563cf1b1de04272eb4348a551c1e7885875353e82e8928c90e0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "7.0.0-dev.9"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mustache_template:
     dependency: transitive
     description:
@@ -217,6 +299,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  sky_engine:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -233,6 +320,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  stream_channel:
+    dependency: transitive
+    description:
+      name: stream_channel
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -249,6 +344,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test_api:
+    dependency: transitive
+    description:
+      name: test_api
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -257,6 +360,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  vector_math:
+    dependency: transitive
+    description:
+      name: vector_math
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  very_good_analysis:
+    dependency: transitive
+    description:
+      name: very_good_analysis
+      sha256: c529563be4cbba1137386f2720fb7ed69e942012a28b13398d8a5e3e6ef551a7
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.0.0"
   web:
     dependency: transitive
     description:
@@ -283,3 +410,4 @@ packages:
     version: "2.2.2"
 sdks:
   dart: ">=3.8.1 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,12 @@
 name: flutter_onscreen_keyboard_workspace
 
+publish_to: none
+
 environment:
-  sdk: ">=3.8.1 <4.0.0"
+  sdk: ^3.8.1
+
+workspace:
+  - packages/flutter_onscreen_keyboard
 
 dev_dependencies:
-  melos: ^6.3.3
+  melos: 7.0.0-dev.9


### PR DESCRIPTION
# Description

This PR introduces predefined factory constructors to `OnscreenKeyboardThemeData`, allowing users to quickly apply built-in themes such as `gBoard()` and `ios()`. These themes provide consistent styling out of the box and simplify customization for common use cases

Fixes #14 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
