### PR TITLE
refactor!: migrate to `KeyboardMode` for layout modes

### DIFF
--- a/packages/flutter_onscreen_keyboard/lib/src/layouts/desktop_layout.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/layouts/desktop_layout.dart
@@ -16,8 +16,8 @@ class DesktopKeyboardLayout extends KeyboardLayout {
   double get aspectRatio => 5 / 2;
 
   @override
-  Map<String, List<KeyboardRow>> get modes => {
-    'default': _defaultMode,
+  Map<String, KeyboardMode> get modes => {
+    'default': KeyboardMode(rows: _defaultMode),
   };
 
   List<KeyboardRow> get _defaultMode => [

--- a/packages/flutter_onscreen_keyboard/lib/src/layouts/mobile_layout.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/layouts/mobile_layout.dart
@@ -20,7 +20,7 @@ class MobileKeyboardLayout extends KeyboardLayout {
   Map<String, KeyboardMode> get modes {
     return {
       'alphabets': KeyboardMode(rows: _alphabetsMode),
-      'symbols': KeyboardMode(rows: _symbolsMode),
+      'symbols': KeyboardMode(rows: _symbolsMode, verticalSpacing: 20),
     };
   }
 

--- a/packages/flutter_onscreen_keyboard/lib/src/layouts/mobile_layout.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/layouts/mobile_layout.dart
@@ -17,10 +17,10 @@ class MobileKeyboardLayout extends KeyboardLayout {
   double get aspectRatio => 4 / 3;
 
   @override
-  Map<String, List<KeyboardRow>> get modes {
+  Map<String, KeyboardMode> get modes {
     return {
-      'alphabets': _alphabetsMode,
-      'symbols': _symbolsMode,
+      'alphabets': KeyboardMode(rows: _alphabetsMode),
+      'symbols': KeyboardMode(rows: _symbolsMode),
     };
   }
 

--- a/packages/flutter_onscreen_keyboard/lib/src/models/layout.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/models/layout.dart
@@ -50,10 +50,14 @@ class KeyboardMode {
   /// [rows] defines the visual layout of the keyboard for this mode.
   const KeyboardMode({
     required this.rows,
+    this.verticalSpacing = 0,
   });
 
   /// The rows of keys displayed in this mode.
   final List<KeyboardRow> rows;
+
+  /// The vertical spacing between rows.
+  final double verticalSpacing;
 }
 
 /// Represents a single row in a keyboard layout.

--- a/packages/flutter_onscreen_keyboard/lib/src/models/layout.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/models/layout.dart
@@ -19,10 +19,10 @@ abstract class KeyboardLayout {
   /// [aspectRatio] controls the width-to-height ratio of the keyboard.
   ///
   /// [modes] is a map of layout modes (like 'letters', 'symbols', etc.)
-  /// to their corresponding rows.
+  /// to their corresponding [KeyboardMode]s.
   const factory KeyboardLayout.custom({
     required double aspectRatio,
-    required Map<String, List<KeyboardRow>> modes,
+    required Map<String, KeyboardMode> modes,
   }) = _CustomKeyboardLayout;
 
   /// {@template keyboardLayout.aspectRatio}
@@ -32,14 +32,28 @@ abstract class KeyboardLayout {
   /// {@endtemplate}
   double get aspectRatio;
 
-  /// A map of layout modes to their rows.
+  /// A map of layout modes to their corresponding [KeyboardMode]s.
   ///
-  /// Each mode (e.g., `'letters'`, `'symbols'`, `'numbers'`) contains a list
-  /// of rows that define what keys should be shown.
+  /// Each mode (e.g., `'letters'`, `'symbols'`, `'numbers'`) defines the
+  /// structure of the keyboard when that mode is active.
+  Map<String, KeyboardMode> get modes;
+}
+
+/// Represents a single layout mode in the keyboard.
+///
+/// A mode is a group of [KeyboardRow]s rendered together.
+/// This allows the keyboard to switch between different input styles,
+/// such as letters, symbols, numbers, etc.
+class KeyboardMode {
+  /// Creates a keyboard mode.
   ///
-  /// This is especially useful for mobile keyboards where pressing keys like
-  /// Shift or Symbol toggles the layout.
-  Map<String, List<KeyboardRow>> get modes;
+  /// [rows] defines the visual layout of the keyboard for this mode.
+  const KeyboardMode({
+    required this.rows,
+  });
+
+  /// The rows of keys displayed in this mode.
+  final List<KeyboardRow> rows;
 }
 
 /// Represents a single row in a keyboard layout.
@@ -80,5 +94,5 @@ class _CustomKeyboardLayout extends KeyboardLayout {
   final double aspectRatio;
 
   @override
-  final Map<String, List<KeyboardRow>> modes;
+  final Map<String, KeyboardMode> modes;
 }

--- a/packages/flutter_onscreen_keyboard/lib/src/raw_onscreen_keyboard.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/raw_onscreen_keyboard.dart
@@ -50,13 +50,14 @@ class RawOnscreenKeyboard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final activeMode = layout.modes[mode]!;
     return AspectRatio(
       aspectRatio: aspectRatio ?? layout.aspectRatio,
       child: Material(
         type: MaterialType.transparency,
         child: Column(
           children: [
-            for (final row in layout.modes[mode]!)
+            for (final row in activeMode.rows)
               Expanded(
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/packages/flutter_onscreen_keyboard/lib/src/raw_onscreen_keyboard.dart
+++ b/packages/flutter_onscreen_keyboard/lib/src/raw_onscreen_keyboard.dart
@@ -56,6 +56,7 @@ class RawOnscreenKeyboard extends StatelessWidget {
       child: Material(
         type: MaterialType.transparency,
         child: Column(
+          spacing: activeMode.verticalSpacing,
           children: [
             for (final row in activeMode.rows)
               Expanded(


### PR DESCRIPTION
# Description

This PR introduces a breaking change by replacing the `Map<String, List<KeyboardRow>>` structure in `KeyboardLayout` with a new `Map<String, KeyboardMode>` format. This provides a more flexible and future-proof abstraction for defining layout modes, enabling advanced configurations per mode.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
